### PR TITLE
Add instruction to disable apt auto (unattended) upgrade in ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ systemctl disable systemd-resolved
 ```
 
 Use [netctl](https://wiki.archlinux.org/index.php/Netctl)
+
+## Ubuntu apt auto upgrades
+
+```
+> cat /etc/apt/apt.conf.d/20auto-upgrades
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Unattended-Upgrade "0";
+```


### PR DESCRIPTION
Add instruction to disable apt auto (unattended) upgrade in ubuntu.  
This feature will upgrade kernel without notifying user and may cause the dis-match between the kernel and some drivers.